### PR TITLE
Fix disappearing copy button on long generated URL

### DIFF
--- a/frontend/modules/components/ResultBox/index.tsx
+++ b/frontend/modules/components/ResultBox/index.tsx
@@ -15,9 +15,9 @@ const ResultBox = (props: ResultBoxProps) => {
   } else {
     return (
       <div className="absolute -bottom-32 w-full h-8 bg-primary py-9 flex flex-row items-center justify-between rounded-md px-4 mt-3 shadow-lg">
-        <div className="text-white max-w-full font-bold truncate pr-10">{`https://ristek.link/${props.alias}`}</div>
+        <div className="text-white font-bold truncate">{`https://ristek.link/${props.alias}`}</div>
         <div
-          className="absolute right-4 bg-primary text-white cursor-pointer"
+          className="text-white cursor-pointer"
           onClick={() => props.onCopy()}
         >
           {props.isCopied ? "Copied!" : "Copy"}


### PR DESCRIPTION
**bug:**
The generated copy button disappears when a user entered a pretty long URL.

**old behavior:**
![image](https://user-images.githubusercontent.com/60605671/137637101-59404c6c-44a7-4a88-af8d-9e258bb39ffd.png)

**new behavior:**
![image](https://user-images.githubusercontent.com/60605671/137637176-a0654928-d6a7-48af-acc7-bdfa2fd39041.png)



